### PR TITLE
Bump IPFS to version 0.4.20

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.11-stretch
+FROM golang:1.12-stretch
 
 ENV GX_IPFS ""
 ENV SRC_DIR /go/src/github.com/ipfs/go-ipfs
 
-ENV BRANCH v0.4.19
+ENV BRANCH v0.4.20
 
 RUN apt-get update && apt-get install -y git
 RUN git clone --branch $BRANCH https://github.com/ipfs/go-ipfs.git $SRC_DIR

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,13 +1,13 @@
 {
   "name": "ipfs.dnp.dappnode.eth",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Dappnode package responsible for providing IPFS connectivity (go-ipfs v0.4.19)",
   "avatar": "/ipfs/QmViXy8BVb8dQ7J9jLK626kcB5Tz2pvvKE43KHo8RNDXxL",
   "type": "dncore",
   "image": {
-    "path": "ipfs.dnp.dappnode.eth_0.1.5.tar.xz",
-    "hash": "/ipfs/QmPbeECpvW7c2CtPCZA4zAdR2rZRyJTmGvHnxJATyppXVQ",
-    "size": 11844958,
+    "path": "",
+    "hash": "",
+    "size": "",
     "volumes": [
       "ipfsdnpdappnodeeth_export:/export",
       "ipfsdnpdappnodeeth_data:/data/ipfs"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ volumes:
 services:
     ipfs.dnp.dappnode.eth:
         build: ./build
-        image: 'ipfs.dnp.dappnode.eth:0.1.5'
+        image: 'ipfs.dnp.dappnode.eth:0.1.6'
         container_name: DAppNodeCore-ipfs.dnp.dappnode.eth
         restart: always
         volumes:


### PR DESCRIPTION
https://github.com/ipfs/go-ipfs/releases/tag/v0.4.20

`This release includes some critical performance and stability fixes so all users should upgrade ASAP.`