### PR TITLE
go-ipfs v0.6.0 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![RIOT DAppNode](https://img.shields.io/badge/RIOT-DAppNode-blue.svg)](https://riot.dappnode.io)
 [![Twitter Follow](https://img.shields.io/twitter/follow/espadrine.svg?style=social&label=Follow)](https://twitter.dappnode.io)
 
-Dappnode package responsible for providing IPFS connectivity (go-ipfs v0.4.15)
+Dappnode package responsible for providing IPFS connectivity (go-ipfs v0.6.0)
 
 It is an AragonApp whose repo is deployed at this address: [0x9dc9dc601f8f177ab558bcabde71786f1ea84091](https://etherscan.io/address/0x9dc9dc601f8f177ab558bcabde71786f1ea84091) and whose ENS address is: [ipfs.dnp.dappnode.eth](https://etherscan.io/enslookup?q=ipfs.dnp.dappnode.eth])
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.12.5-stretch
 
 ENV SRC_DIR /go/src/github.com/ipfs/go-ipfs
 
-ENV TAG v0.5.1
+ENV TAG v0.6.0
 
 RUN apt-get update && apt-get install -y wget ca-certificates
 #RUN git clone --branch $BRANCH https://github.com/ipfs/go-ipfs.git $SRC_DIR

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "ipfs.dnp.dappnode.eth",
   "version": "0.2.10",
-  "upstreamVersion": "v0.5.0",
+  "upstreamVersion": "v0.6.0",
   "description": "Dappnode package responsible for providing IPFS connectivity",
   "type": "dncore",
   "author": "DAppNode Association <admin@dappnode.io> (https://github.com/dappnode)",


### PR DESCRIPTION
These changes pull in [go-ipfs v0.6.0](https://github.com/ipfs/go-ipfs/releases/tag/v0.6.0) for the next DNP_IPFS release.