### PR TITLE
Update to hardcoded fs repo version

### DIFF
--- a/build/dappnode_entrypoint.sh
+++ b/build/dappnode_entrypoint.sh
@@ -41,7 +41,7 @@ IPFS_GO_MINIMUM_STABLE_VERSION=0.8.0
 
 if [ "$IPFS_REPO_STABLE_VERSION" -gt "$IPFS_REPO_CURRENT_VERSION" ] && [ "$(echo -e "${IPFS_GO_CURRENT_VERSION}\n${IPFS_GO_MINIMUM_STABLE_VERSION}" | sort -V | head -n1)" == "${IPFS_GO_MINIMUM_STABLE_VERSION}" ]; then
     echo "Migrating fs repo from ${IPFS_REPO_CURRENT_VERSION} to ${IPFS_REPO_STABLE_VERSION}"
-    fs-repo-migrations -y
+    fs-repo-migrations -to "$IPFS_REPO_STABLE_VERSION" -y
 fi
 
 # Check profile set


### PR DESCRIPTION
Due to the IPFS fs repo migration necessary for the core release v0.2.43, the update must be a controlled update to a hardcoded version instead of the default `latest`

Source:
```
/ # fs-repo-migrations --help
Usage of fs-repo-migrations:
  -distpath string
    	specify the distributions build to use
  -revert-ok
    	allow running migrations backward
  -to string
    	repo version to upgrade to, or "latest" for latest repo version (default "latest")
  -v	print latest migration available and exit
  -y	answer yes to all prompts
```
