### PR TITLE
Default auto-discovery config triggers SecOps alerts.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     environment:
       - EXTRA_OPTS
       - DATASTORE_STORAGEMAX=50GB
-      - PROFILE=custom
+      - PROFILE=server
       - ROUTING=dhtclient
       - DISCOVERY_MDNS_ENABLED=true
       - SWARM_DISABLENATPORTMAP=false


### PR DESCRIPTION
Having the IPFS profile defaulted to auto-discover means by the time you get a chance to see the admin panel the server is already in the process of an abuse ban.

<img width="585" alt="image" src="https://user-images.githubusercontent.com/631881/146661043-0e3401f1-3697-405e-9e70-5b29578f2ba1.png">

