### PR TITLE
Add migration depending on architecture

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,11 +1,9 @@
 # Create intermediate container for the fs-repo-migrations binary. Use a lightweight alpine image
 FROM alpine:3.14.2 as fs-repo-migrations
-# copy the migrations binary from the url https://dist.ipfs.tech/fs-repo-migrations/v2.0.2/fs-repo-migrations_v2.0.2_darwin-arm64.tar.gz
-# to the container and extract it
-RUN wget https://dist.ipfs.tech/fs-repo-migrations/v2.0.2/fs-repo-migrations_v2.0.2_linux-amd64.tar.gz && \
-    tar -xvf fs-repo-migrations_v2.0.2_linux-amd64.tar.gz && \
-    mv fs-repo-migrations/fs-repo-migrations /usr/local/bin/ && \
-    rm -rf fs-repo-migrations_v2.0.2_linux-amd64.tar.gz fs-repo-migrations
+
+# Copy the download migration script
+COPY download_migration.sh /tmp/
+RUN /tmp/download_migration.sh
 
 ARG UPSTREAM_VERSION
 FROM ipfs/kubo:${UPSTREAM_VERSION}

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,14 @@
+# Create intermediate container for the fs-repo-migrations binary. Use a lightweight alpine image
+FROM alpine:3.14.2 as fs-repo-migrations
+# copy the migrations binary from the url https://dist.ipfs.tech/fs-repo-migrations/v2.0.2/fs-repo-migrations_v2.0.2_darwin-arm64.tar.gz
+# to the container and extract it
+RUN wget https://dist.ipfs.tech/fs-repo-migrations/v2.0.2/fs-repo-migrations_v2.0.2_linux-amd64.tar.gz && \
+    tar -xvf fs-repo-migrations_v2.0.2_linux-amd64.tar.gz && \
+    mv fs-repo-migrations/fs-repo-migrations /usr/local/bin/ && \
+    rm -rf fs-repo-migrations_v2.0.2_linux-amd64.tar.gz fs-repo-migrations
+
 ARG UPSTREAM_VERSION
 FROM ipfs/kubo:${UPSTREAM_VERSION}
 COPY dappnode_entrypoint.sh /usr/local/bin/
+COPY --from=fs-repo-migrations /usr/local/bin/fs-repo-migrations /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/dappnode_entrypoint.sh"]

--- a/src/dappnode_entrypoint.sh
+++ b/src/dappnode_entrypoint.sh
@@ -7,6 +7,8 @@ user=ipfs
 # IPFS_PATH=/data/ipfs
 repo="$IPFS_PATH"
 
+fs-repo-migrations
+
 # If the user changes then the volumes could not be used and the ipfs init will fail
 if [ $(id -u) -eq 0 ]; then
     echo "Changing user to $user"
@@ -54,14 +56,6 @@ ipfs config --json Datastore.StorageMax "\"$DATASTORE_STORAGEMAX\""
 
 ## Provides origin isolation between content roots: https://github.com/ipfs/kubo/blob/master/docs/config.md#gatewaypublicgateways-usesubdomains
 ipfs config --json Gateway.PublicGateways '{"ipfs.dappnode": { "NoDNSLink": false, "Paths": [ "/ipfs" , "/ipns" ], "UseSubdomains": true }}'
-
-# Add handler
-sigterm_handler() {
-    echo -e "Caught singal. Stopping ipfs service gracefully"
-    exit 0
-}
-
-trap 'sigterm_handler' TERM INT
 
 # Possible values for EXTRA_OPTS (must have --): https://docs.ipfs.io/reference/cli/#ipfs-daemon
 # Join arguments with EXTRA_OPTS if var not empty.

--- a/src/download_migration.sh
+++ b/src/download_migration.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+case $(uname -m) in
+    "x86_64") ARCHITECTURE=amd64; export ARCHITECTURE; ARCH_URL="https://dist.ipfs.tech/fs-repo-migrations/v2.0.2/fs-repo-migrations_v2.0.2_linux-amd64.tar.gz"; export ARCH_URL;;
+    "i686") ARCHITECTURE=386; export ARCHITECTURE; ARCH_URL="https://dist.ipfs.tech/fs-repo-migrations/v2.0.2/fs-repo-migrations_v2.0.2_linux-386.tar.gz"; export ARCH_URL;;
+    "aarch64") ARCHITECTURE=arm64; export ARCHITECTURE; ARCH_URL="https://dist.ipfs.tech/fs-repo-migrations/v2.0.2/fs-repo-migrations_v2.0.2_linux-arm64.tar.gz"; export ARCH_URL;;
+    "armv7l") ARCHITECTURE=arm; export ARCHITECTURE; ARCH_URL="https://dist.ipfs.tech/fs-repo-migrations/v2.0.2/fs-repo-migrations_v2.0.2_linux-arm.tar.gz"; export ARCH_URL;;
+    *) echo "Unsupported architecture: $(uname -m)" && exit 1;;
+esac
+
+echo "Architecture: ${ARCHITECTURE}"
+echo "Downloading from URL: ${ARCH_URL}"
+
+wget ${ARCH_URL} && \
+    tar -xvf "fs-repo-migrations_v2.0.2_linux-${ARCHITECTURE}.tar.gz" && \
+    mv fs-repo-migrations/fs-repo-migrations /usr/local/bin/ && \
+    rm -rf "fs-repo-migrations_v2.0.2_linux-${ARCHITECTURE}.tar.gz" fs-repo-migrations


### PR DESCRIPTION
branched from PR  https://github.com/dappnode/DNP_IPFS/pull/104.

Added a script that checks which migration to download before executing it in `dappnode_entrypoint.sh`.

To be tested and merged when IPFS arm issue on +v0.20.0 versions is solved https://github.com/ipfs/kubo/issues/9901#issuecomment-1634100273