### PR TITLE
arm64 friendly IPFS container

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -4,10 +4,18 @@ ARG UPSTREAM_VERSION
 FROM alpine:3.14.2 as fs-repo-migrations
 # copy the migrations binary from the url https://dist.ipfs.tech/fs-repo-migrations/v2.0.2/fs-repo-migrations_v2.0.2_darwin-arm64.tar.gz
 # to the container and extract it
-RUN wget https://dist.ipfs.tech/fs-repo-migrations/v2.0.2/fs-repo-migrations_v2.0.2_linux-amd64.tar.gz && \
-    tar -xvf fs-repo-migrations_v2.0.2_linux-amd64.tar.gz && \
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        ARCH="amd64"; \
+    elif [ "$ARCH" = "aarch64" ]; then \
+        ARCH="arm64"; \
+    else \
+        echo "Unsupported architecture: $ARCH" && exit 1; \
+    fi && \
+    wget https://dist.ipfs.tech/fs-repo-migrations/v2.0.2/fs-repo-migrations_v2.0.2_linux-$ARCH.tar.gz && \
+    tar -xvf fs-repo-migrations_v2.0.2_linux-$ARCH.tar.gz && \
     mv fs-repo-migrations/fs-repo-migrations /usr/local/bin/ && \
-    rm -rf fs-repo-migrations_v2.0.2_linux-amd64.tar.gz fs-repo-migrations
+    rm -rf fs-repo-migrations_v2.0.2_linux-$ARCH.tar.gz fs-repo-migrations
 
 
 FROM ipfs/kubo:${UPSTREAM_VERSION}


### PR DESCRIPTION
<!-- For DAppNode core members, once the Pull Request is created, do not forget to:
1.  Link issues to the PR if available
2.  Mention dappnode core members
3.  Add proper labels
-->

## Context
The binary used for fs-repo-migrations is currently amd64 only.  This means that IPFS containers on arm64 platforms fail when trying to execute an x86 binary, leading to a container fail/restart loop.

## Approach
This tweak pulls arch-specific binaries by mapping the output of uname -m to the relevant arch tag.


## Test instructions

<!-- MANDATORY: please, do not skip this step, it is very importand for DAppNode team to have simple and well defined instructions on how to test this PR.
-->
build and run this container on arm64 machines like rock5 and MacOS M* machines.

