### PR TITLE
Revert "bump ipfs/kubo to v0.25.0"

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "ipfs.dnp.dappnode.eth",
-  "version": "0.2.22",
-  "upstreamVersion": "v0.25.0",
+  "version": "0.2.20",
+  "upstreamVersion": "v0.22.0",
   "description": "Dappnode package responsible for providing IPFS connectivity",
   "type": "dncore",
   "architectures": ["linux/amd64", "linux/arm64"],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     build:
       context: ./src
       args:
-        UPSTREAM_VERSION: v0.25.0
+        UPSTREAM_VERSION: v0.22.0
     image: "ipfs.dnp.dappnode.eth:0.2.20"
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
Reverts dappnode/DNP_IPFS#121

Error running 0.25.0 upstream version 

```
runtime/cgo: pthread_create failed: Operation not permitted
SIGABRT: abort
PC=0x7fc8c5e46d3c m=0 sigcode=18446744073709551610

goroutine 0 [idle]:
runtime: g 0: unknown pc 0x7fc8c5e46d3c
stack: frame={sp:0x7ffd8cfbe720, fp:0x0} stack=[0x7ffd8c7bfba0,0x7ffd8cfbebb0)
0x00007ffd8cfbe620:  0x0000000000000000  0x0000000000000000 
0x00007ffd8cfbe630:  0x0000000000000000  0x0000000000000000 
0x00007ffd8cfbe640:  0x0000000000000000  0x00007ffd8cfbe830 
0x00007ffd8cfbe650:  0x0000000000ed6f99 <runtime.(*scavengeIndex).alloc+0x0000000000000079>  0x0000000002030000 <github.com/dgraph-io/badger.Open+0x0000000000000620> 
0x00007ffd8cfbe660:  0x0000000000000000  0x0000000000000000 
0x00007ffd8cfbe670:  0x0000000000000000  0x0000000000000000 
```