### PR TITLE
Add seccomp unconfined

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
       - SWARM_CONNMGR_LOWWATER=600
       - SWARM_CONNMGR_HIGHWATER=900
       - SWARM_CONNMGR_GRACEPERIOD=20s
+    security_opt:
+      - "seccomp:unconfined"
     networks:
       dncore_network:
         aliases:


### PR DESCRIPTION
Running with docker version 20 fails with

```
runtime/cgo: pthread_create failed: Operation not permitted
SIGABRT: abort
PC=0x7f5ba5158d3c m=0 sigcode=18446744073709551610

goroutine 0 [idle]:
runtime: g 0: unknown pc 0x7f5ba5158d3c
stack: frame={sp:0x7fff3e71b080, fp:0x0} stack=[0x7fff3df1c500,0x7fff3e71b510)
0x00007fff3e71af80:  0x00007f5ba51545b0  0x000000001c000004 
0x00007fff3e71af90:  0x00007f5ba5109fd0  0x0000000000000000 
0x00007fff3e71afa0:  0x0000000000000000  0x00007fff3e71b190 
```

See https://github.com/docker-library/golang/issues/467


