### PR TITLE
Add dappnode config

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,26 @@
 ARG UPSTREAM_VERSION
+
+# Create intermediate container for the fs-repo-migrations binary. Use a lightweight alpine image
+FROM alpine:3.14.2 as fs-repo-migrations
+# copy the migrations binary from the url https://dist.ipfs.tech/fs-repo-migrations/v2.0.2/fs-repo-migrations_v2.0.2_darwin-arm64.tar.gz
+# to the container and extract it
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        ARCH="amd64"; \
+    elif [ "$ARCH" = "aarch64" ]; then \
+        ARCH="arm64"; \
+    else \
+        echo "Unsupported architecture: $ARCH" && exit 1; \
+    fi && \
+    wget https://dist.ipfs.tech/fs-repo-migrations/v2.0.2/fs-repo-migrations_v2.0.2_linux-$ARCH.tar.gz && \
+    tar -xvf fs-repo-migrations_v2.0.2_linux-$ARCH.tar.gz && \
+    mv fs-repo-migrations/fs-repo-migrations /usr/local/bin/ && \
+    rm -rf fs-repo-migrations_v2.0.2_linux-$ARCH.tar.gz fs-repo-migrations
+
 FROM ipfs/kubo:${UPSTREAM_VERSION}
+
+# Copy the fs-repo-migrations binary from the intermediate container
+COPY --from=fs-repo-migrations /usr/local/bin/fs-repo-migrations /usr/local/bin/fs-repo-migrations
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -4,6 +4,8 @@ set -e
 user=ipfs
 repo="$IPFS_PATH"
 
+echo "Starting IPFS entrypoint script"
+
 if [ "$(id -u)" -eq 0 ]; then
   echo "Changing user to $user"
   # ensure folder is writable
@@ -11,6 +13,8 @@ if [ "$(id -u)" -eq 0 ]; then
   # restart script with new privileges
   exec gosu "$user" "$0" "$@"
 fi
+
+echo "Running as user: $(id -un)"
 
 # 2nd invocation with regular user
 ipfs version
@@ -51,7 +55,9 @@ fi
 
 # IMPORTANT: this is a copy of the original entrypoint to add dappnode custom config to inject our gateways
 # In order to be able to execute config commands, the fs-repo-migrations must be run first
-fs-repo-migrations 
+echo "Running fs-repo-migrations"
+/usr/local/bin/fs-repo-migrations 
+echo "Running IPFS config commands"
 ipfs config --json Gateway.PublicGateways '{"ipfs.dappnode": { "NoDNSLink": false, "Paths": [ "/ipfs" , "/ipns" ], "UseSubdomains": false }}'
 ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["*"]'
 ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "POST", "GET]'

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -52,7 +52,7 @@ fi
 
 # IMPORTANT: this is a copy of the original entrypoint to add dappnode custom config to inject our gateways
 ipfs config --json Gateway.PublicGateways '{"ipfs.dappnode": { "NoDNSLink": false, "Paths": [ "/ipfs" , "/ipns" ], "UseSubdomains": false }}'
-ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["http://ipfs.dappnode:5001", "http://localhost:3000", "http://127.0.0.1:5001", "https://webui.ipfs.io"]'
+ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["*"]'
 ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "POST", "GET]'
 
 find /container-init.d -maxdepth 1 -type f -iname '*.sh' -print0 | sort -z | xargs -n 1 -0 -r container_init_run

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -52,6 +52,8 @@ fi
 
 # IMPORTANT: this is a copy of the original entrypoint to add dappnode custom config to inject our gateways
 ipfs config --json Gateway.PublicGateways '{"ipfs.dappnode": { "NoDNSLink": false, "Paths": [ "/ipfs" , "/ipns" ], "UseSubdomains": false }}'
+ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["http://ipfs.dappnode:5001", "http://localhost:3000", "http://127.0.0.1:5001", "https://webui.ipfs.io"]'
+ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "POST", "GET]'
 
 find /container-init.d -maxdepth 1 -type f -iname '*.sh' -print0 | sort -z | xargs -n 1 -0 -r container_init_run
 

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -65,6 +65,8 @@ ipfs config --json Gateway.PublicGateways '{"ipfs.dappnode": { "NoDNSLink": fals
 ipfs bootstrap add /ip4/65.109.51.31/tcp/4001/p2p/12D3KooWLdrSru7LzYY4YDcfnJsrJeshTQooR2j38NkGvoj2yADp
 # Add to bootstrap list the dev Dappnode IPFS gateway 
 ipfs bootstrap add /ip4/167.86.114.131/tcp/4001/p2p/12D3KooWCAx5zWejUDotqc7dcvpvNstM9eZRdtdne1oXZ1DpdLFb
+# list bootstrap peers
+ipfs bootstrap list
 
 find /container-init.d -maxdepth 1 -type f -iname '*.sh' -print0 | sort -z | xargs -n 1 -0 -r container_init_run
 

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -56,11 +56,15 @@ fi
 # IMPORTANT: this is a copy of the original entrypoint to add dappnode custom config to inject our gateways
 # In order to be able to execute config commands, the fs-repo-migrations must be run first
 echo "Running fs-repo-migrations"
-/usr/local/bin/fs-repo-migrations 
+/usr/local/bin/fs-repo-migrations -y
 echo "Running IPFS config commands"
-ipfs config --json Gateway.PublicGateways '{"ipfs.dappnode": { "NoDNSLink": false, "Paths": [ "/ipfs" , "/ipns" ], "UseSubdomains": false }}'
 ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["*"]'
-ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "POST", "GET]'
+ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "GET", "POST"]'
+ipfs config --json Gateway.PublicGateways '{"ipfs.dappnode": { "NoDNSLink": false, "Paths": [ "/ipfs" , "/ipns" ], "UseSubdomains": false }}'
+# Add to bootstrap list the production Dappnode IPFS gateway
+ipfs bootstrap add /ip4/65.109.51.31/tcp/4001/p2p/12D3KooWLdrSru7LzYY4YDcfnJsrJeshTQooR2j38NkGvoj2yADp
+# Add to bootstrap list the dev Dappnode IPFS gateway 
+ipfs bootstrap add /ip4/167.86.114.131/tcp/4001/p2p/12D3KooWCAx5zWejUDotqc7dcvpvNstM9eZRdtdne1oXZ1DpdLFb
 
 find /container-init.d -maxdepth 1 -type f -iname '*.sh' -print0 | sort -z | xargs -n 1 -0 -r container_init_run
 

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -15,7 +15,6 @@ fi
 # 2nd invocation with regular user
 ipfs version
 
-
 if [ -e "$repo/config" ]; then
   echo "Found IPFS fs-repo at $repo"
 else
@@ -51,6 +50,8 @@ else
 fi
 
 # IMPORTANT: this is a copy of the original entrypoint to add dappnode custom config to inject our gateways
+# In order to be able to execute config commands, the fs-repo-migrations must be run first
+fs-repo-migrations 
 ipfs config --json Gateway.PublicGateways '{"ipfs.dappnode": { "NoDNSLink": false, "Paths": [ "/ipfs" , "/ipns" ], "UseSubdomains": false }}'
 ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["*"]'
 ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "POST", "GET]'


### PR DESCRIPTION
- Add dappnode config on entrypoint:
  - Allow origin to access UI
  - Do not use subdomain on path `/ipfs`
  - Add to bootstrap list dappnode prod an dev ipfs gatways peer IDs
- Run repo migrations on startup so `ipfs config` commands can be run without issues

Fixes https://github.com/dappnode/DNP_IPFS/issues/142
