### PR TITLE
add configure ipfs script

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,29 +1,10 @@
 ARG UPSTREAM_VERSION
-
-# Create intermediate container for the fs-repo-migrations binary. Use a lightweight alpine image
-FROM alpine:3.14.2 as fs-repo-migrations
-# copy the migrations binary from the url https://dist.ipfs.tech/fs-repo-migrations/v2.0.2/fs-repo-migrations_v2.0.2_darwin-arm64.tar.gz
-# to the container and extract it
-RUN ARCH=$(uname -m) && \
-    if [ "$ARCH" = "x86_64" ]; then \
-        ARCH="amd64"; \
-    elif [ "$ARCH" = "aarch64" ]; then \
-        ARCH="arm64"; \
-    else \
-        echo "Unsupported architecture: $ARCH" && exit 1; \
-    fi && \
-    wget https://dist.ipfs.tech/fs-repo-migrations/v2.0.2/fs-repo-migrations_v2.0.2_linux-$ARCH.tar.gz && \
-    tar -xvf fs-repo-migrations_v2.0.2_linux-$ARCH.tar.gz && \
-    mv fs-repo-migrations/fs-repo-migrations /usr/local/bin/ && \
-    rm -rf fs-repo-migrations_v2.0.2_linux-$ARCH.tar.gz fs-repo-migrations
-
 FROM ipfs/kubo:${UPSTREAM_VERSION}
 
-# Copy the fs-repo-migrations binary from the intermediate container
-COPY --from=fs-repo-migrations /usr/local/bin/fs-repo-migrations /usr/local/bin/fs-repo-migrations
-
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+COPY configure-ipfs.sh /usr/local/bin/configure-ipfs.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/configure-ipfs.sh
+
 
 # Override the default entrypoint to use our wrapper script
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/src/configure-ipfs.sh
+++ b/src/configure-ipfs.sh
@@ -3,25 +3,33 @@ set -e
 
 echo "Starting IPFS post-config script..."
 
-CONFIG_COMMANDS="
-  ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '[\"*\"]'
-  ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '[\"PUT\", \"GET\", \"POST\"]'
-  ipfs config --json Gateway.PublicGateways '{\"ipfs.dappnode\": { \"NoDNSLink\": false, \"Paths\": [ \"/ipfs\" , \"/ipns\" ], \"UseSubdomains\": false }}'
-  ipfs bootstrap add /ip4/65.109.51.31/tcp/4001/p2p/12D3KooWLdrSru7LzYY4YDcfnJsrJeshTQooR2j38NkGvoj2yADp
-  ipfs bootstrap add /ip4/167.86.114.131/tcp/4001/p2p/12D3KooWCAx5zWejUDotqc7dcvpvNstM9eZRdtdne1oXZ1DpdLFb
-"
+# List of config commands, one per line
+CONFIG_COMMANDS='
+ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin "[\"*\"]"
+ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods "[\"PUT\", \"GET\", \"POST\"]"
+ipfs config --json Gateway.PublicGateways "{\"ipfs.dappnode\": { \"NoDNSLink\": false, \"Paths\": [ \"/ipfs\" , \"/ipns\" ], \"UseSubdomains\": false }}"
+ipfs bootstrap add /ip4/65.109.51.31/tcp/4001/p2p/12D3KooWLdrSru7LzYY4YDcfnJsrJeshTQooR2j38NkGvoj2yADp
+ipfs bootstrap add /ip4/167.86.114.131/tcp/4001/p2p/12D3KooWCAx5zWejUDotqc7dcvpvNstM9eZRdtdne1oXZ1DpdLFb
+'
 
-until ipfs id >/dev/null 2>&1; do
+# Wait for IPFS daemon to be ready, without locking ipfs.repo
+until ipfs --api=/ip4/127.0.0.1/tcp/5001 id >/dev/null 2>&1; do
   echo "Waiting for IPFS daemon to be ready..."
   sleep 2
 done
 
+
 echo "Daemon is ready, applying IPFS config..."
 
-for cmd in "$CONFIG_COMMANDS"; do
+# Run each config command, retrying until success
+echo "$CONFIG_COMMANDS" | while IFS= read -r cmd; do
+  [ -z "$cmd" ] && continue  # skip empty lines
   echo "Running: $cmd"
-  sh -c "$cmd" || echo "Failed: $cmd (retrying later)"
+  until sh -c "$cmd"; do
+    echo "Retrying: $cmd"
+    sleep 2
+  done
 done
 
-echo "Listing final bootstrap peers:"
+echo "Final bootstrap list:"
 ipfs bootstrap list

--- a/src/configure-ipfs.sh
+++ b/src/configure-ipfs.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -e
+
+echo "Starting IPFS post-config script..."
+
+CONFIG_COMMANDS="
+  ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '[\"*\"]'
+  ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '[\"PUT\", \"GET\", \"POST\"]'
+  ipfs config --json Gateway.PublicGateways '{\"ipfs.dappnode\": { \"NoDNSLink\": false, \"Paths\": [ \"/ipfs\" , \"/ipns\" ], \"UseSubdomains\": false }}'
+  ipfs bootstrap add /ip4/65.109.51.31/tcp/4001/p2p/12D3KooWLdrSru7LzYY4YDcfnJsrJeshTQooR2j38NkGvoj2yADp
+  ipfs bootstrap add /ip4/167.86.114.131/tcp/4001/p2p/12D3KooWCAx5zWejUDotqc7dcvpvNstM9eZRdtdne1oXZ1DpdLFb
+"
+
+until ipfs id >/dev/null 2>&1; do
+  echo "Waiting for IPFS daemon to be ready..."
+  sleep 2
+done
+
+echo "Daemon is ready, applying IPFS config..."
+
+for cmd in "$CONFIG_COMMANDS"; do
+  echo "Running: $cmd"
+  sh -c "$cmd" || echo "Failed: $cmd (retrying later)"
+done
+
+echo "Listing final bootstrap peers:"
+ipfs bootstrap list

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -53,20 +53,8 @@ else
   unset IPFS_SWARM_KEY_FILE
 fi
 
-# IMPORTANT: this is a copy of the original entrypoint to add dappnode custom config to inject our gateways
-# In order to be able to execute config commands, the fs-repo-migrations must be run first
-echo "Running fs-repo-migrations"
-/usr/local/bin/fs-repo-migrations -y
-echo "Running IPFS config commands"
-ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["*"]'
-ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "GET", "POST"]'
-ipfs config --json Gateway.PublicGateways '{"ipfs.dappnode": { "NoDNSLink": false, "Paths": [ "/ipfs" , "/ipns" ], "UseSubdomains": false }}'
-# Add to bootstrap list the production Dappnode IPFS gateway
-ipfs bootstrap add /ip4/65.109.51.31/tcp/4001/p2p/12D3KooWLdrSru7LzYY4YDcfnJsrJeshTQooR2j38NkGvoj2yADp
-# Add to bootstrap list the dev Dappnode IPFS gateway 
-ipfs bootstrap add /ip4/167.86.114.131/tcp/4001/p2p/12D3KooWCAx5zWejUDotqc7dcvpvNstM9eZRdtdne1oXZ1DpdLFb
-# list bootstrap peers
-ipfs bootstrap list
+# Start ipfs config script in background
+configure-ipfs.sh &
 
 find /container-init.d -maxdepth 1 -type f -iname '*.sh' -print0 | sort -z | xargs -n 1 -0 -r container_init_run
 


### PR DESCRIPTION
- Moved IPFS custom config commands to a new script: `configure-ipfs.sh`.
- The script runs in the background from `entrypoint.sh` and waits for the ipfs daemon to be ready before applying config. This ensures that the migration will be done.
- Preserves `exec ipfs "$@"` as the main container process.
- Ensures non-blocking, reliable config application with retries.